### PR TITLE
Strip off Pod formatting codes from code on render

### DIFF
--- a/lib/Docky/Renderer/Node.pm6
+++ b/lib/Docky/Renderer/Node.pm6
@@ -39,8 +39,23 @@ monitor Docky::Renderer::Node is Node::To::HTML {
         # Extend rules here if necessary...
     }
 
+    sub strip-off-formatting($node) {
+        given $node {
+            when Pod::FormattingCode {
+                $node.contents;
+            }
+            default {
+                $node
+            }
+        }
+    }
+
     method highlight-code($node) {
-        my $code = $node.contents.join;
+        my $code = $node.contents.map(&strip-off-formatting).join;
+        # my $code = $node.contents.join;
+        # if $code.contains('<strong>') {
+        #     say $node.contents.raku;
+        # }
 
         $lock.protect({
             unless $hl-proc.started {


### PR DESCRIPTION
As there is no neat way to preserve both Pod highlighting
codes such as `B<>` and code coloring, for long time examples,
where for some reason the codes were used, were not colored.

As it's easier to understand what's what with Raku syntax in examples
such as:

```raku
my $excerpt = q:to/END/;
Here's some unimportant text.
=begin code
    This code block is what we're after.
    We'll use 'ff' to get it.
=end code
More unimportant text.
END

my @codelines = gather for $excerpt.lines {
    take $_ if "=begin code" ff "=end code"
}
say @codelines.join("\n");
```

we address the same issue by prefering coloring over
codes like bold or italics. In code it means unwrapping the
Pod::FormattingCode nodes into text we can then highlight.