### PR TITLE
Fix IRC link

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "title-page": "Documentable",
   "pod-root-path": "https://github.com/Raku/doc/blob/master/doc",
-  "irc-link": "https://webchat.freenode.net/?channels=#raku",
+  "irc-link": "https://web.libera.chat/?channel=#raku",
   "kinds": [
     {
       "kind": "language",


### PR DESCRIPTION
Hello,
as time passed, the community IRC channels moved from freenode to libera. I noticed this site hasn't been updated to contain the new link yet. I simply took the link from the traditional site and added it here. :)