### PR TITLE
Raku planet link updated

### DIFF
--- a/lib/Docky/Constants.pm6
+++ b/lib/Docky/Constants.pm6
@@ -31,7 +31,7 @@ our @resource-links is export =
     { :title<Downloadable docs>, :url</404> };
 
 our @explore-links is export =
-    { :title<Raku Blog Aggregator>, :url<https://pl6anet.org/> },
+    { :title<Raku Blog Aggregator>, :url<https://planet.raku.org/> },
     { :title<Rakudo Weekly>, :url<https://rakudoweekly.blog/> },
     { :title<The Weekly Challenge>, :url<https://perlweeklychallenge.org/> },
     { :title<Raku Advent Calendar>, :url<https://raku-advent.blog/> };


### PR DESCRIPTION
Hello,

I checked the links and I have open questions - and also, this minor fix.
- the "downloadable docs" link leads to the 404 page - is this going to change by the time the site goes public?
- the perl6book site, apparently created by Moritz Lenz back in 2017, leaves a very mixed impression (bluntly put, it feels seriously outdated and abandoned)... I'm not sure if it's worth keeping, unless it can be revised somehow
- the one I'm proposing to change - p6lanet.org does work but I think the name has been officially changed since so I think it's better to adopt

Thank you again for pushing things forward. I'm gonna take a look at the "code snippets are editable" issue soon.