### PR TITLE
Retrieve pages of a category in alphabetical order of the title.

### DIFF
--- a/lib/Docky/Host.pm6
+++ b/lib/Docky/Host.pm6
@@ -80,7 +80,7 @@ class Docky::Host {
             %index-pages{$key.Str} = $config.get-categories($key).map(-> $category {
                 my $pages = %all-pages{$key}.grep({
                     try .pod.config<category> eq $category<name>
-                }).grep(so *).cache;
+                }).grep(so *).sort(*.name).cache;
                 %( title => $category<display-text>, :$pages )
             }).cache;
         }


### PR DESCRIPTION
Hello,

I intend this modification to fix https://github.com/Altai-man/docs.raku.org/issues/72. As far as I could understand the issue, this modification could be sufficient; it definitely changes the category-items of the language site to alphabetical ordering.

This seemed to be the right place to intervene because this is where category items are retrieved and stored. I see no major disadvantages to always retrieve them as sorted - I rather see advantages if anything but of course this is not the only solution.