### PR TITLE
Make Cro::WebApp also use version 0.8.7

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,7 +10,7 @@
   "auth": "Write me!",
   "depends": [
     "Cro::HTTP:ver<0.8.7>",
-    "Cro::WebApp",
+    "Cro::WebApp:ver<0.8.7>",
     "Documentable",
     "Pod::From::Cache:ver<0.2+>",
     "Pod::To::HTML:ver<0.8+>",


### PR DESCRIPTION
I noticed that Cro::WebApp also depends on versioned utilities of Cro, this means that two different versions of Cro are installed as dependencies: 0.8.7 and the latest.

Since the intention was clearly to make things work with 0.8.7, _for now_, I fixed Cro::WebApp to that version, too.